### PR TITLE
fix/module-status

### DIFF
--- a/admin/controller/module/tawkto.php
+++ b/admin/controller/module/tawkto.php
@@ -76,6 +76,8 @@ class Tawkto extends Controller
 	public function install(): void
 	{
 		$this->load->model('setting/event');
+		$this->load->model('setting/setting');
+		$this->load->model('setting/store');
 
 		$data = array(
 			'code' => 'tawkto_widget',
@@ -87,6 +89,10 @@ class Tawkto extends Controller
 		);
 
 		$this->model_setting_event->addEvent($data);
+
+		$currentSettings = $this->getCurrentSettingsFor(0);
+		$currentSettings['module_tawkto_status'] = '1';
+		$this->model_setting_setting->editSetting('module_tawkto', $currentSettings, 0);
 	}
 
 	/**


### PR DESCRIPTION
Module status is based on `module_<name>_status` https://github.com/opencart/opencart/blob/0ddd916ca3f7a32fd83adce759238db277d0e3ee/upload/admin/controller/extension/module.php#L86

Set module status to enabled on install hook

