### PR TITLE
Fix widget not showing on oc4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Visit our [Help Center](https://help.tawk.to/) for answers to FAQs
 
 ## Changelog
 
+### 1.1.3
+* Fix widget not loading on oc4.1.x.x
+
 ### 1.1.2
 * Fix module status
 

--- a/admin/controller/module/tawkto.php
+++ b/admin/controller/module/tawkto.php
@@ -82,7 +82,7 @@ class Tawkto extends Controller
 		$data = array(
 			'code' => 'tawkto_widget',
 			'description' => 'tawk.to chat widget',
-			'trigger' => 'catalog/view/common/content_bottom/after',
+			'trigger' => 'catalog/view/common/footer/after',
 			'action' => 'extension/tawkto/module/tawkto',
 			'status' => 1,
 			'sort_order' => 0

--- a/catalog/controller/module/tawkto.php
+++ b/catalog/controller/module/tawkto.php
@@ -29,7 +29,7 @@ class Tawkto extends Controller
 	/**
 	 * Entry point
 	 */
-	public function index()
+	public function index(&$route, &$args, &$output)
 	{
 		$this->load->model('setting/setting');
 
@@ -57,7 +57,10 @@ class Tawkto extends Controller
 			$data['widget_id'] = $widget['widget_id'];
 		}
 
-		return $this->load->view('extension/tawkto/module/tawkto', $data);
+		$view = $this->load->view('extension/tawkto/module/tawkto', $data);
+
+		$end_body_tag = '</body>';
+		$output = str_replace($end_body_tag, $view . $end_body_tag, $output);
 	}
 
 	/**

--- a/catalog/view/template/module/tawkto.twig
+++ b/catalog/view/template/module/tawkto.twig
@@ -5,7 +5,7 @@
 @license GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
 #}
 
-<!--Start of Tawk.to Script (1.1.2)-->
+<!--Start of Tawk.to Script (1.1.3)-->
 <script type="text/javascript">
 	var Tawk_API = Tawk_API || {}, Tawk_LoadStart = new Date();
 
@@ -90,4 +90,4 @@
 		s0.parentNode.insertBefore(s1, s0);
 	})();
 </script>
-<!--End of Tawk.to Script (1.1.2)-->
+<!--End of Tawk.to Script (1.1.3)-->

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "tawk/tawk-opencart4",
     "description": "tawk.to extension module for Opencart 4",
-    "version": "1.1.2",
+    "version": "1.1.3",
     "type": "project",
     "license": "GPL3",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "01b52cea40bb541ab3961800127e7f2d",
+    "content-hash": "6e74960efa4e273eab546482da47a1a3",
     "packages": [
         {
             "name": "tawk/url-utils",

--- a/install.json
+++ b/install.json
@@ -1,6 +1,6 @@
 {
 	"name": "Tawk.to Live Chat",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"author": "tawk.to",
 	"link": "https://tawk.to"
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated the chat widget’s placement so it now appears after the footer, enhancing its visibility and integration on the page.
  - Improved the widget’s rendering process for a smoother display experience.
  
- **Bug Fixes**
  - Resolved an issue preventing the widget from loading on OpenCart version 4.1.x.x.

- **Documentation**
  - Added a changelog entry for version 1.1.3 in the README file. 

- **Version Updates**
  - Incremented version numbers to 1.1.3 across relevant files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->